### PR TITLE
Add Bank Name field, otherwise API does not work

### DIFF
--- a/src/Modules/BankAccount.php
+++ b/src/Modules/BankAccount.php
@@ -18,6 +18,7 @@ class BankAccount extends Entity
     public $entityVersion;
     public $entityId;
     public $entityType;
+    public $bankName;
 
     public function __construct(array $array = array())
     {


### PR DESCRIPTION
Hi, the API returns Bank Name field and when PHP tries to convert it to object it fails. You don't have a develop branch yet I guess and I didn't want to create it for this small change, even through your contribution file recommends it.