### PR TITLE
Updated SDK and phpunit tests to work against current API state.

### DIFF
--- a/src/Modules/BankAccount.php
+++ b/src/Modules/BankAccount.php
@@ -13,6 +13,7 @@ class BankAccount extends Entity
     public $accountType;
     public $phone;
     public $country;
+    public $bankName;
     public $bankCode;
     public $default;
     public $entityVersion;

--- a/src/Modules/ECheck.php
+++ b/src/Modules/ECheck.php
@@ -15,6 +15,7 @@ class ECheck extends Entity
     public $checkNumber;
     public $authCode;
     public $refundDetail;
+    public $type;
 
     public function __construct(array $array = array())
     {

--- a/tests/BankAccountTest.php
+++ b/tests/BankAccountTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use QuickBooksOnline\Payments\Operations\BankAccountOperations;
 use QuickBooksOnline\Payments\PaymentClient;
 
-final class CardTest extends TestCase
+final class BankAccountTest extends TestCase
 {
   private function createInstance()
   {

--- a/tests/ECheckTest.php
+++ b/tests/ECheckTest.php
@@ -25,7 +25,7 @@ final class ECheckTest extends TestCase
        "accountNumber"=> "1100000033345678"
      ],
      "description"=> "Check Auth test call",
-     "checkNumber"=> "12345678",
+     "checkNumber"=> str_pad(strval(mt_rand(1,99999999)), 8, '0', STR_PAD_LEFT),
      "paymentMode"=> "WEB",
      "amount"=> "5.55",
      "context"=> [

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace QuickBooksOnline\Tests;
 
+use PHPUnit\Framework\TestCase;
 use QuickBooksOnline\Payments\Operations\OperationsConverter;
-
 
 final class OperationsTest extends TestCase
 {


### PR DESCRIPTION
When attempting to run the phpunit tests against the current master branch several issues were encountered.  These include

- Missing bankName property on the BankAccount model
- Missing type property on the ECheck model
- Class name collision/duplication between the BankAccountTest.php and CardTest.php files
- Error created by check number reuse
- Hardcoded local file paths

This patch / PR attempts to address these shortcomings and allows for a full and successful phpunit run.

Edit: The user must still update the token in TestClientCreator.php and the refresh token in GuzzleClientTest.php