### PR TITLE
Implement "Get a Card" method described in API documentation.

### DIFF
--- a/src/Operations/CardOperations.php
+++ b/src/Operations/CardOperations.php
@@ -53,6 +53,18 @@ class CardOperations
     }
 
     /**
+     * Get a card associated with a Customer
+     */
+    public static function getCard($customerID, string $cardId, string $requestId, $context): RequestInterface
+    {
+        $request = RequestFactory::createStandardIntuitRequest(RequestType::CARD);
+        $request->setMethod(RequestInterface::GET)
+            ->setUrl($context->getBaseUrl() . EndpointUrls::CUSTOMER_URL . "/" . $customerID . "/cards" . "/" . $cardId)
+            ->setHeader($context->getStandardHeaderWithRequestID($requestId));
+        return $request;
+    }
+
+    /**
      * Create a Card from Token
      */
     public static function createCardFromToken($customerID, string $tokenValue, $requestId, $context): RequestInterface

--- a/src/PaymentClient.php
+++ b/src/PaymentClient.php
@@ -185,6 +185,20 @@ class PaymentClient
         return $response;
     }
 
+    public function getCard($customerID, string $cardId, string $requestId = ""): ResponseInterface
+    {
+        if (empty($requestId)) {
+            $requestId = ClientContext::generateRequestID();
+        }
+        $request = CardOperations::getCard($customerID, $cardId, $requestId, $this->getContext());
+        $this->before($request, $this);
+        $response = $this->httpClient->send($request);
+        $this->after($response, $this);
+        $this->intercept($request, $response);
+        OperationsConverter::updateResponseBodyToObj($response);
+        return $response;
+    }
+
     public function deleteCard($customerID, string $cardId, string $requestId = ""): ResponseInterface
     {
         if (empty($requestId)) {

--- a/tests/CardTest.php
+++ b/tests/CardTest.php
@@ -115,6 +115,29 @@ final class CardTest extends TestCase
         $client->deleteCard($customerId, $id2);
     }
 
+    public function testFindACustomerCardOnSandbox(): void
+    {
+        $client = $this->createInstance();
+        $card = $this->createCardBody();
+        $customerId = rand();
+
+        /** Add a test card */
+        $response = $client->createCard($card, $customerId);
+        $id1 = $response->getBody()->id;
+        $secureCardNumber1 = $response->getBody()->number;
+
+        /** Retrieve the test card */
+        $response2 = $client->getCard($customerId, $id1);
+        $id2 = $response2->getBody()->id;
+        $secureCardNumber2 = $response->getBody()->number;
+
+        /** Make sure the retrieved secure card matches the originally added card */
+        $this->assertEquals($id1, $id2);
+        $this->assertEquals($secureCardNumber1, $secureCardNumber2);
+
+        $client->deleteCard($customerId, $id1);
+    }
+
     public function testCreateCardToken(): void
     {
         $client = $this->createInstance();


### PR DESCRIPTION
Per #9 since the functionality to retrieve a previously stored Card object wasn't implemented, I've added the methods and a unit test based on existing coding style.

Now a developer can access a previously secured credit card for it's details via the PaymentClient class.