### PR TITLE
Add $verificationStatus as a property to BankAccount Module

### DIFF
--- a/src/Modules/BankAccount.php
+++ b/src/Modules/BankAccount.php
@@ -19,6 +19,7 @@ class BankAccount extends Entity
     public $entityVersion;
     public $entityId;
     public $entityType;
+    public $verificationStatus;
 
     public function __construct(array $array = array())
     {


### PR DESCRIPTION
verificationStatus is being returned with the response, and if this property doesn't exist, it returns a RuntimeException