### PR TITLE
Allow one to specify timeout options when constructing PaymentClient

### DIFF
--- a/src/PaymentClient.php
+++ b/src/PaymentClient.php
@@ -59,7 +59,10 @@ class PaymentClient
         }else{
             $this->context = new ClientContext();
         }
-        $this->httpClient = ClientFactory::buildCurlClient();
+        $this->httpClient = ClientFactory::buildCurlClient(
+            $context['connection_time_out'] ?? 10,
+            $context['request_time_out'] ?? 100
+        );
 
         $this->interceptors = array();
     }


### PR DESCRIPTION
Hi,

This PR adds a couple of config options (`connection_time_out` and `request_time_out`) when constructing `PaymentClient`. This will allow one to adjust the curl timeout, like so:

```
$client = new PaymentClient([
    'access_token' => "your access token",
    'environment' => "sandbox", //  or 'environment' => "production"
    'connection_time_out' => 200,
    'request_time_out' => 200
]);
```

Fixes https://github.com/intuit/PHP-Payments-SDK/issues/17