### PR TITLE
Don't duplicate requests to charge or void payments

### DIFF
--- a/src/PaymentClient.php
+++ b/src/PaymentClient.php
@@ -92,7 +92,6 @@ class PaymentClient
         }
         $request = ChargeOperations::createChargeRequest($charge, $requestId, $this->getContext());
 
-        $response = $this->httpClient->send($request);
         $this->before($request, $this);
         $response = $this->httpClient->send($request);
         $this->after($response, $this);
@@ -107,7 +106,6 @@ class PaymentClient
         }
         $request = ChargeOperations::voidTransaction($chargeRequestId, $requestId, $this->getContext());
 
-        $this->httpClient->send($request);
         $this->before($request, $this);
         $response = $this->httpClient->send($request);
         $this->after($response, $this);


### PR DESCRIPTION
Fixes #30

Both the charge() and voidChargeTransaction() methods are currently sending duplicate requests, and then ignoring the first response.

This seemingly wasn't a problem before (just would delay overall method time), however today the subsequent requests started returning empty responses (#30), which results in transactions going through that appear to have failed on the client's end. I'm guessing the API changed today to start checking the request-id or something as an idempotency key, and ignoring duplicates.