### PR TITLE
Support for PHP 8 and Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "phpunit/phpunit": "^8"
   },
   "require": {
-    "guzzlehttp/guzzle": "^6.3",
-    "psr/log": "^1.0.1"
+    "guzzlehttp/guzzle": "^7.0",
+    "psr/log": "^3.0.0"
   }
 }

--- a/src/PaymentClient.php
+++ b/src/PaymentClient.php
@@ -92,7 +92,6 @@ class PaymentClient
         }
         $request = ChargeOperations::createChargeRequest($charge, $requestId, $this->getContext());
 
-        $response = $this->httpClient->send($request);
         $this->before($request, $this);
         $response = $this->httpClient->send($request);
         $this->after($response, $this);
@@ -107,7 +106,6 @@ class PaymentClient
         }
         $request = ChargeOperations::voidTransaction($chargeRequestId, $requestId, $this->getContext());
 
-        $this->httpClient->send($request);
         $this->before($request, $this);
         $response = $this->httpClient->send($request);
         $this->after($response, $this);


### PR DESCRIPTION
This upgrades to use Guzzle 7 to support PHP 8.x  (related to #37 )
Also has the fixes for duplicated calls #31 